### PR TITLE
ts - core - SkeletonBinary attachment reading fix

### DIFF
--- a/spine-ts/core/src/SkeletonBinary.ts
+++ b/spine-ts/core/src/SkeletonBinary.ts
@@ -457,9 +457,9 @@ module spine {
 				case AttachmentType.Point: {
 					let point = this.attachmentLoader.newPointAttachment(skin, name);
 					if (point == null) return null;
+					point.rotation = reader.readFloat();
 					point.x = reader.readFloat() * scale;
 					point.y = reader.readFloat() * scale;
-					point.rotation = reader.readFloat();
 
 					if (nonessential) {
 						let color = reader.readColor();


### PR DESCRIPTION
According to the official C# implementation. `rotation` should be read before `x` and `y`:
https://github.com/EsotericSoftware/spine-runtimes/blob/654c20e5b0e523040b6366bbd1042510d2645134/spine-csharp/src/SkeletonBinary.cs#L453-L455
```csharp
float rotation = ReadFloat(input);
float x = ReadFloat(input);
float y = ReadFloat(input);
```

However, in our implementation, `rotation` being read after them.
https://github.com/esterTion/spine-runtimes/blob/3.6/spine-ts/core/src/SkeletonBinary.ts#L460-L462
```typescript
point.x = reader.readFloat() * scale;
point.y = reader.readFloat() * scale;
point.rotation = reader.readFloat();
```